### PR TITLE
Update parse_trans to 3.3.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {erl_opts, [debug_info]}.
 {deps, [
-    {parse_trans, "3.1.0"}
+    {parse_trans, "3.3.0"}
 ]}.


### PR DESCRIPTION
This fixes the deprecation warnings of `erlang:get_stacktrace()` in erlang
versions >=21.