### PR TITLE
Switch TravisCI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu18
+    name: Erlang/OTP ${{matrix.otp}} / rebar3 ${{matrix.rebar3}}
+    strategy:
+      matrix:
+        otp: ['18.3', '25.0']
+        rebar3: ['3.18.0']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          rebar3-version: ${{matrix.rebar3}}
+      - run: rebar3 compile
+      - run: rebar3 eunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
----
-language: erlang
-otp_release:
-- 18.3
-- 19.3
-- 20.0


### PR DESCRIPTION
We also bump the OTP version to support 25.0.